### PR TITLE
Remove "Quick install for Windows Users"

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -108,49 +108,6 @@ script should display the file structure. This is a handy tool to have
 around when you want to explore the contents of any HDF4 file.
 
 
-Quick install for Windows Users
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Download the complete HDF4 binary package from the link given
-   below.  These packages include all libraries needed to compile
-   pyhdf. There are two binary packages to choose from depending on
-   whether or not you want to compile pyhdf with SZIP encoding enabled
-   or disabled.  There are different licensing implications for each
-   choice (see `the HDF page
-   <http://hdfgroup.com/doc_resource/SZIP/>`_ for more details on the
-   licensing of SZIP).
-
-   - `HDF4 with encoding enabled <http://pysclint.sourceforge.net/pyhdf/hdf4-all-enc.zip>`_
-   - `HDF4 with encoding disabled <http://pysclint.sourceforge.net/pyhdf/hdf4-all-noenc.zip>`_
-
-2. Unzip the selected package into a directory of your choice (e.g. ``C:\HDF4``).  
-
-3. Go to the pyhdf source directory.
-
-4. Build the package in one of the two following ways:
-
-   * Set the HDF4 environment variable to the directory where you unpacked the
-     binary and (e.g. ``C:\HDF4``). Then run the following::
-
-	   python setup.py build
-
-   * Run ``python setup.py build --hdf4 <directory of unzipped package>`` where
-     ``<directory of unzipped package>`` is the location where you unzipped the
-     downloaded HDF4 binary (e.g. ``C:\HDF4``).
-
-   *NOTE*: If you are using the mingw32 compiler and are using the
-   standard Python binary distribution, then you need to specify -c
-   mingw32 on the command line as well.
-
-5. To install pyhdf or build a binary distribution (bdist_msi,
-   bdist_wininst, bdist_egg, etc.), run one of the following commands::
-
-	python setup.py install
-	python setup.py bdist_msi
-	python setup.py bdist_wininst
-	python setup.py bdist_egg
-
-
 Further notes
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -92,38 +92,6 @@ if sys.platform.startswith('linux'):
     if not include_dirs and os.path.exists(d):
         include_dirs.append(d)
 
-if sys.platform == 'win32':
-    try:
-        k = sys.argv.index('--hdf4')
-        baseloc = sys.argv[k+1]
-        del sys.argv[k]
-        del sys.argv[k]
-    except (ValueError, IndexError):
-        baseloc = None
-    if not baseloc:
-        baseloc = os.environ.get('HDF4', None)
-    if baseloc:
-        # fix include_dirs and library_dirs
-        #  based on fixed set of paths
-        if not path.exists(baseloc):
-            print("\n******\n%s not found\n******\n\n" % baseloc)
-            raise RuntimeError(msg)
-        if not path.isdir(baseloc):
-            print("\n******\n%s not a directory \n******\n\n" % baseloc)
-            raise RuntimeError(msg)
-        alldirs = os.listdir(baseloc)
-        include_dirs = []
-        library_dirs = []
-        for adir in alldirs:
-            if not path.isdir(path.sep.join([baseloc, adir])):
-                continue
-            if adir.startswith('42'):
-                include_dirs.append(path.sep.join([baseloc, adir, 'include']))
-                library_dirs.append(path.sep.join([baseloc, adir, 'dll']))
-            library_dirs.append(path.sep.join([baseloc, adir, 'lib']))
-        print("Using include_dirs = ", include_dirs)
-        print("Using library_dirs = ", library_dirs)
-
 for p in include_dirs + library_dirs:
     if not path.exists(p):
         print("\n******\n%s not found\n******\n\n" % p)


### PR DESCRIPTION
* This method of installation uses a custom binary distribution of
Windows libraries that the previous pyhdf maintainer provided. The
binary distribution contained hdf4 and all it's dependencies (zlib,
libjpeg, and szip). These libraries are  most likely outdated at this
point and there is no 64-bit version. I have no plans on updating them.

* This removes use of the environment variable `HDF4`, which must be set
to the directory containing the above mentioned binary distribution.
conda-build sets it to the HDF4 version `4.2`, which makes builds fail.
(see https://github.com/conda-forge/pyhdf-feedstock/pull/20#discussion_r264302801)

* You can still use the custom binary distribution if you really wanted
by setting the environment variables LIBRARY_DIRS and INCLUDE_DIRS
appropriately, but I don't recommend using them anymore.

* The "quick install" for Windows right now is to use conda-forge pyhdf
build.