### PR TITLE
Remove python versions 2.6 and 3.3 from the travis linux builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ language: python
 matrix:
   include:
     - os: linux
-      python: "2.6"
-    - os: linux
       python: "2.7"
-    - os: linux
-      python: "3.3"
     - os: linux
       python: "3.4"
     - os: linux


### PR DESCRIPTION
These versions are not available for ubuntu 16.04:

Supported versions at the bottom of this page:

  https://docs.travis-ci.com/user/languages/python/

See also:

  - https://travis-ci.org/fhs/pyhdf/jobs/614629417
  - https://en.wikipedia.org/wiki/History_of_Python#Version_release_dates
      Python 2.6 - October 1, 2008
      Python 2.7 - July 3, 2010

      Python 3.3 - September 29, 2012
      Python 3.4 - March 16, 2014