### PR TITLE
pyproject.toml: add file that describes build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = [  # PEP 508 specifications.
+	"numpy",
+	"setuptools",
+	"wheel"
+]


### PR DESCRIPTION
This file is specified in PEP 518. It describes build dependencies for
`pip`. Pyhdf is a bit unusual in that it imports `numpy` in `setup.py`,
so we need to tell `pip` about this extra build dependency.

Fixes #37