### PR TITLE
fixes annoying install bug for linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if sys.platform == 'win32':
 elif _use_hdf4alt(library_dirs):
     libraries = ["mfhdfalt", "dfalt"]
 else:
-    libraries = ["mfhdf", "df"]
+    libraries = ["mfhdf", "hdf"]
 
 if szip_installed:
     extra_compile_args = []


### PR DESCRIPTION
Compiling HDF4 doesn't yield a libdf.a file... but it does give libhdf.a, and it seems suspicious that other platforms (windows) uses ["mfhdf", "hdf", ... ], while linux has ["mfhdf", "df"], with no mention of "hdf".

This change allows pyhdf to be pip installed on a unix-like system that has HDF4 installed; otherwise, pip install fails complaining that the linker can't find -ldf