### PR TITLE
Update cibuildwheel to include wheels for 3.10 (and drop 3.5)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,13 +20,13 @@ jobs:
 
         - name: Install cibuildwheel
           run: |
-            python -m pip install cibuildwheel==1.9.0
+            python -m pip install cibuildwheel==2.3.1
 
         - name: Build wheels for linux python versions
           run: |
             python -m cibuildwheel --output-dir dist
           env:
-            CIBW_BUILD: '{cp,pp}3*-*'
+            CIBW_BUILD: '{cp,pp}3*-many*'
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
             CIBW_BEFORE_ALL_LINUX: yum -y install epel-release hdf hdf-devel && ln -s /usr/lib64/hdf/lib* /usr/lib64/
             CIBW_ARCHS_LINUX: 'x86_64'


### PR DESCRIPTION
Hi there!

I was installing pyhdf in a python 3.10 environment and it initially failed due to missing header files ("hdf.h").
Therefore, I went ahead and updated the used cibuildwheel version, which now is able to build python 3.10 build targets.
Unfortunately, in the same process python 3.5 was dropped. If 3.5 wheels are needed, we can add another build step to use the old cibuildwheel version to build them.

With the update, the following packages will be build:
 - pyhdf-0.10.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 - pyhdf-0.10.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 - pyhdf-0.10.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 - pyhdf-0.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 - pyhdf-0.10.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 - pyhdf-0.10.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 - pyhdf-0.10.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

To complete the automated build, we also could add mac-os and windows builds, if needed.
Let me know what you think, happy to help!