### PR TITLE
Fix reads of 8-bit signed char SDSs

### DIFF
--- a/pyhdf/hdfext.i
+++ b/pyhdf/hdfext.i
@@ -325,14 +325,17 @@ static PyObject * _SDreaddata_0(int32 sds_id, int32 data_type,
         }
 
         /*
-         * Create output numpy array.
+         * Create output numpy array. We provide 1 for the itemsize argument to
+         * PyArray_New to handle to case when num_type is NPY_STRING. All other
+         * num_type possibilities are fixed-size types, so itemsize is ignored.
          */
     if ((num_type = HDFtoNumericType(data_type)) < 0)    {
         PyErr_SetString(PyExc_ValueError, "data_type not compatible with numpy");
         return NULL;
         }
-    if ((array = (PyArrayObject *)
-                 PyArray_SimpleNew(outRank, dims, num_type)) == NULL)
+    array = (PyArrayObject *)PyArray_New(&PyArray_Type, outRank, dims, num_type,
+                                         NULL, NULL, 1, 0, NULL);
+    if (array == NULL)
         return NULL;
         /*
          * Load it from the SDS.

--- a/pyhdf/hdfext_wrap.c
+++ b/pyhdf/hdfext_wrap.c
@@ -3964,14 +3964,17 @@ static PyObject * _SDreaddata_0(int32 sds_id, int32 data_type,
         }
 
         /*
-         * Create output numpy array.
+         * Create output numpy array. We provide 1 for the itemsize argument to
+         * PyArray_New to handle to case when num_type is NPY_STRING. All other
+         * num_type possibilities are fixed-size types, so itemsize is ignored.
          */
     if ((num_type = HDFtoNumericType(data_type)) < 0)    {
         PyErr_SetString(PyExc_ValueError, "data_type not compatible with numpy");
         return NULL;
         }
-    if ((array = (PyArrayObject *)
-                 PyArray_SimpleNew(outRank, dims, num_type)) == NULL)
+    array = (PyArrayObject *)PyArray_New(&PyArray_Type, outRank, dims, num_type,
+                                         NULL, NULL, 1, 0, NULL);
+    if (array == NULL)
         return NULL;
         /*
          * Load it from the SDS.

--- a/pyhdf/test_SD.py
+++ b/pyhdf/test_SD.py
@@ -6,6 +6,7 @@ import pyhdf.SD
 import shutil
 import tempfile
 from numpy.testing import assert_array_equal
+from pathlib import Path
 from pyhdf.SD import SDC
 
 def test_long_varname():
@@ -61,3 +62,11 @@ def test_negative_int8():
         sd.end()
     finally:
         shutil.rmtree(temp)
+
+def test_char():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        hdf_file = str(Path(temp_dir) / "test.hdf")
+        sd = pyhdf.SD.SD(hdf_file, SDC.WRITE | SDC.CREATE)
+        sds = sd.create("test_sds", SDC.CHAR, [5])
+        sds[:] = "ABCDE"
+        assert_array_equal(sds[:], np.array(list("ABCDE"), "S2"))


### PR DESCRIPTION
This proposed fix addresses an issue encountered after a recent upgrade from pyhdf 0.10.5 to 0.11.3. When reading an SDS of type `SDC.CHAR` with version 0.11.3, I'd get the following error:
```
In [2]: SD("MYD03.A2023213.0000.061.2023213152719.hdf").select("Scan Type").get()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 SD("MYD03.A2023213.0000.061.2023213152719.hdf").select("Scan Type").get()

File ~/Code/pyhdf/pyhdf/SD.py:1920, in SDS.get(self, start, count, stride)
   1916 if not data_type in SDC.equivNumericTypes:
   1917     raise HDF4Error('get cannot currently deal with '\
   1918                      'the SDS data type')
-> 1920 return _C._SDreaddata_0(self._id, data_type, start, count, stride)

File ~/Code/pyhdf/pyhdf/hdfext.py:333, in _SDreaddata_0(sds_id, data_type, start, edges, stride)
    332 def _SDreaddata_0(sds_id, data_type, start, edges, stride):
--> 333     return _hdfext._SDreaddata_0(sds_id, data_type, start, edges, stride)

ValueError: data type must provide an itemsize
```
I tracked the problem down to use of `PyArray_SimpleNew` with typenum `NPY_STRING`, which fails because that type code requires a size specification. This change instead uses `PyArray_New` with an `itemsize` of 1, which reproduces the 0.10.5 `SDC.CHAR` read behavior. All the non-`NPY_STRING` type codes are fixed-size in which case `PyArray_New` ignores the `itemsize` argument so behavior for these type codes should be unaffected.