### PR TITLE
Include hdf.h instead of hdfi.h removed in 4.3.0.

### DIFF
--- a/pyhdf/hdfext.i
+++ b/pyhdf/hdfext.i
@@ -203,7 +203,7 @@ extern void _HEprint(void);
 
 
 %{
-#include "hdfi.h"     /* declares int32, float32, etc */
+#include "hdf.h"      /* declares int32, float32, etc */
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/ndarraytypes.h"

--- a/pyhdf/hdfext_wrap.c
+++ b/pyhdf/hdfext_wrap.c
@@ -3842,7 +3842,7 @@ void _HEprint(void)   {
     }
 
 
-#include "hdfi.h"     /* declares int32, float32, etc */
+#include "hdf.h"      /* declares int32, float32, etc */
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/ndarraytypes.h"


### PR DESCRIPTION
As reported in #70, `hdfi.h` has been removed in HDF 4.3.0 which causes build failures.

Replacing the the include with `hdf.h` resolves this.

Closes: #70 