### PR TITLE
Fix README PyPI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Tests](https://github.com/fhs/pyhdf/actions/workflows/tests.yml/badge.svg)](https://github.com/fhs/pyhdf/actions/workflows/tests.yml)
-[![Pypi build](https://github.com/fhs/pyhdf/actions/workflows/package.yml/badge.svg)](https://github.com/fhs/pyhdf/actions/workflows/package.yml)
+[![Pypi build](https://github.com/fhs/pyhdf/actions/workflows/package_and_publish.yml/badge.svg)](https://github.com/fhs/pyhdf/actions/workflows/package_and_publish.yml)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pyhdf/badges/version.svg)](https://anaconda.org/conda-forge/pyhdf)
 
 # pyhdf


### PR DESCRIPTION
Currently the PyPI Badge is broken:

![broken badge example](https://github.com/user-attachments/assets/fb0084e0-a5c3-403b-b60e-45f305750025)

This fixes that 🙂 